### PR TITLE
feat: apply PitchGuard dark gradient UI

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -49,21 +49,18 @@ const writingAnimation = `
 
 @keyframes blink-caret {
   from, to { border-color: transparent; }
-  50% { border-color: #468BFF; }
+  50% { border-color: #0078D2; }
 }
 `;
 
 // Add this near your other styles at the top of the file
 const colorAnimation = `
 @keyframes colorTransition {
-  0% { stroke: #468BFF; }
-  15% { stroke: #8FBCFA; }
-  30% { stroke: #468BFF; }
-  45% { stroke: #FE363B; }
-  60% { stroke: #FF9A9D; }
-  75% { stroke: #FDBB11; }
-  90% { stroke: #F6D785; }
-  100% { stroke: #468BFF; }
+  0% { stroke: #0078D2; }
+  25% { stroke: #ffffff; }
+  50% { stroke: #8A1C33; }
+  75% { stroke: #d9d9d9; }
+  100% { stroke: #0078D2; }
 }
 
 .animate-colors {
@@ -177,19 +174,17 @@ function App() {
   const [isCopied, setIsCopied] = useState(false);
 
   // Add new state for color cycling
-  const [loaderColor, setLoaderColor] = useState("#468BFF");
+  const [loaderColor, setLoaderColor] = useState("#0078D2");
   
   // Add useEffect for color cycling
   useEffect(() => {
     if (!isResearching) return;
     
     const colors = [
-      "#468BFF", // Blue
-      "#8FBCFA", // Light Blue
-      "#FE363B", // Red
-      "#FF9A9D", // Light Red
-      "#FDBB11", // Yellow
-      "#F6D785", // Light Yellow
+      "#0078D2", // Bright blue
+      "#ffffff", // White
+      "#8A1C33", // Crimson
+      "#d9d9d9", // Light gray
     ];
     
     let currentIndex = 0;
@@ -822,9 +817,9 @@ function App() {
 
   // Add these styles at the top of the component, before the return statement
   const glassStyle: GlassStyle = {
-    base: "backdrop-filter backdrop-blur-lg bg-white/80 border border-gray-200 shadow-xl",
-    card: "backdrop-filter backdrop-blur-lg bg-white/80 border border-gray-200 shadow-xl rounded-2xl p-6",
-    input: "backdrop-filter backdrop-blur-lg bg-white/80 border border-gray-200 shadow-xl pl-10 w-full rounded-lg py-3 px-4 text-gray-900 focus:border-[#468BFF]/50 focus:outline-none focus:ring-1 focus:ring-[#468BFF]/50 placeholder-gray-400 bg-white/80 shadow-none"
+    base: "backdrop-filter backdrop-blur-2xl bg-white/10 border border-white/15 shadow-[0_20px_60px_rgba(0,0,0,0.45)] text-white",
+    card: "backdrop-filter backdrop-blur-2xl bg-white/10 border border-white/15 shadow-[0_20px_60px_rgba(0,0,0,0.45)] rounded-2xl p-6 text-white",
+    input: "backdrop-filter backdrop-blur-xl bg-[#0B1831]/70 border border-white/20 shadow-[0_10px_40px_rgba(0,0,0,0.45)] pl-10 w-full rounded-lg py-3 px-4 text-white focus:border-[#0078D2]/60 focus:outline-none focus:ring-1 focus:ring-[#0078D2]/50 placeholder-[#D9D9D9]/60"
   };
 
   // Add these to your existing styles
@@ -950,9 +945,11 @@ function App() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-white via-gray-50 to-white p-8 relative">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgba(70,139,255,0.35)_1px,transparent_0)] bg-[length:24px_24px] bg-center"></div>
-      <div className="max-w-5xl mx-auto space-y-8 relative">
+    <div className="min-h-screen relative overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#0B1831] via-[#112449] to-[#8A1C33]"></div>
+      <div className="absolute inset-0 opacity-70 bg-[radial-gradient(circle_at_20%_20%,rgba(0,120,210,0.35),transparent_55%)]"></div>
+      <div className="absolute inset-0 opacity-60 bg-[radial-gradient(circle_at_80%_0%,rgba(138,28,51,0.35),transparent_60%)]"></div>
+      <div className="max-w-5xl mx-auto space-y-8 relative px-6 py-10">
         {/* Header Component */}
         <Header glassStyle={glassStyle.card} />
 
@@ -966,10 +963,10 @@ function App() {
 
         {/* Error Message */}
         {error && (
-          <div 
-            className={`${glassStyle.card} border-[#FE363B]/30 bg-[#FE363B]/10 ${fadeInAnimation.fadeIn} ${isResetting ? 'opacity-0 transform -translate-y-4' : 'opacity-100 transform translate-y-0'} font-['DM_Sans']`}
+          <div
+            className={`${glassStyle.card} border-[#8A1C33]/40 bg-[#8A1C33]/20 ${fadeInAnimation.fadeIn} ${isResetting ? 'opacity-0 transform -translate-y-4' : 'opacity-100 transform translate-y-0'} font-['DM_Sans']`}
           >
-            <p className="text-[#FE363B]">{error}</p>
+            <p className="text-[#FFD3DC]">{error}</p>
           </div>
         )}
 

--- a/ui/src/components/CurationExtraction.tsx
+++ b/ui/src/components/CurationExtraction.tsx
@@ -23,7 +23,7 @@ const CurationExtraction: React.FC<CurationExtractionProps> = ({
   isResetting,
   loaderColor
 }) => {
-  const glassStyle = "backdrop-filter backdrop-blur-lg bg-white/80 border border-gray-200 shadow-xl";
+  const glassStyle = "backdrop-filter backdrop-blur-2xl bg-white/10 border border-white/15 shadow-[0_20px_60px_rgba(0,0,0,0.45)] text-white";
   const glassCardStyle = `${glassStyle} rounded-2xl p-6`;
 
   return (
@@ -36,10 +36,10 @@ const CurationExtraction: React.FC<CurationExtractionProps> = ({
         className="flex items-center justify-between cursor-pointer"
         onClick={onToggleExpand}
       >
-        <h2 className="text-xl font-semibold text-gray-900">
+        <h2 className="text-xl font-semibold text-white">
           Curation and Extraction
         </h2>
-        <button className="text-gray-600 hover:text-gray-900 transition-colors">
+        <button className="text-[#D9D9D9] hover:text-white transition-colors">
           {isExpanded ? (
             <ChevronUp className="h-6 w-6" />
           ) : (
@@ -55,19 +55,19 @@ const CurationExtraction: React.FC<CurationExtractionProps> = ({
           {['company', 'industry', 'financial', 'news'].map((category) => {
             const counts = enrichmentCounts?.[category as keyof EnrichmentCounts];
             return (
-              <div key={category} className="backdrop-blur-2xl bg-white/95 border border-gray-200/50 rounded-xl p-3 shadow-none">
-                <h3 className="text-sm font-medium text-gray-700 mb-2 capitalize">{category}</h3>
-                <div className="text-gray-900">
+              <div key={category} className="backdrop-blur-2xl bg-white/5 border border-white/15 rounded-xl p-3 shadow-[0_10px_40px_rgba(0,0,0,0.35)]">
+                <h3 className="text-sm font-medium text-[#D9D9D9] mb-2 capitalize">{category}</h3>
+                <div className="text-white stream-fade">
                   <div className="text-2xl font-bold mb-1">
                     {counts ? (
-                      <span className="text-[#468BFF]">
+                      <span className="text-[#79C1FF]">
                         {counts.enriched}
                       </span>
                     ) : (
                       <Loader2 className="animate-spin h-6 w-6 mx-auto loader-icon" style={{ stroke: loaderColor }} />
                     )}
                   </div>
-                  <div className="text-sm text-gray-600">
+                  <div className="text-sm text-[#D9D9D9]">
                     {counts ? (
                       `selected from ${counts.total}`
                     ) : (
@@ -82,7 +82,7 @@ const CurationExtraction: React.FC<CurationExtractionProps> = ({
       </div>
 
       {!isExpanded && enrichmentCounts && (
-        <div className="mt-2 text-sm text-gray-600">
+        <div className="mt-2 text-sm text-[#D9D9D9]">
           {Object.values(enrichmentCounts).reduce((acc, curr) => acc + curr.enriched, 0)} documents enriched from {Object.values(enrichmentCounts).reduce((acc, curr) => acc + curr.total, 0)} total
         </div>
       )}

--- a/ui/src/components/ExamplePopup.tsx
+++ b/ui/src/components/ExamplePopup.tsx
@@ -87,11 +87,11 @@ const ExamplePopup: React.FC<ExamplePopupProps> = ({
   if (!visible) return null;
 
   return (
-    <div 
+    <div
       ref={exampleRef}
-      className={`absolute -top-14 left-8 ${glassStyle.card} bg-white/90 shadow-lg border-blue-200 cursor-pointer z-10 
-                 flex items-center px-3 py-2 space-x-2 transform transition-all duration-300 
-                 hover:shadow-xl hover:bg-white/95 hover:-translate-y-1 hover:border-blue-300 group`}
+      className={`absolute -top-14 left-8 ${glassStyle.card} bg-white/10 border-white/15 shadow-[0_20px_60px_rgba(0,0,0,0.45)] cursor-pointer z-10
+                 flex items-center px-3 py-2 space-x-2 transform transition-all duration-300
+                 hover:shadow-[0_30px_80px_rgba(0,0,0,0.5)] hover:bg-white/15 hover:-translate-y-1 hover:border-white/30 group`}
       onClick={() => onExampleSelect(EXAMPLE_COMPANIES[selectedExample])}
       style={{
         borderTopLeftRadius: '12px',
@@ -100,13 +100,13 @@ const ExamplePopup: React.FC<ExamplePopupProps> = ({
         borderBottomLeftRadius: '4px',
       }}
     >
-      <Sparkles className="h-4 w-4 text-blue-500 group-hover:text-blue-600 animate-pulse group-hover:animate-none group-hover:scale-110 transition-all" />
+      <Sparkles className="h-4 w-4 text-[#79C1FF] group-hover:text-white animate-pulse group-hover:animate-none group-hover:scale-110 transition-all" />
       <div>
-        <span className="text-sm font-medium text-gray-700 group-hover:text-gray-800 transition-colors">Try an example: </span>
-        <span 
-          className={`text-sm font-bold text-blue-600 group-hover:text-blue-700 transition-all inline-block
+        <span className="text-sm font-medium text-[#D9D9D9] group-hover:text-white transition-colors">Try an example: </span>
+        <span
+          className={`text-sm font-bold text-[#79C1FF] group-hover:text-white transition-all inline-block
             ${isNameAnimating ? 'opacity-0 transform -translate-y-3 scale-95' : 'opacity-100 transform translate-y-0 scale-100'}`}
-          style={{ 
+          style={{
             transitionDuration: '150ms',
             transitionTimingFunction: 'cubic-bezier(0.2, 0, 0.4, 1)'
           }}
@@ -114,7 +114,7 @@ const ExamplePopup: React.FC<ExamplePopupProps> = ({
           {EXAMPLE_COMPANIES[selectedExample].name}
         </span>
       </div>
-      <ArrowRight className="h-3.5 w-3.5 text-blue-500 group-hover:text-blue-600 group-hover:translate-x-0.5 transition-all" />
+      <ArrowRight className="h-3.5 w-3.5 text-[#79C1FF] group-hover:text-white group-hover:translate-x-0.5 transition-all" />
     </div>
   );
 };

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -64,11 +64,11 @@ const Header: React.FC<HeaderProps> = ({ glassStyle, title = 'Company Research A
   return (
     <div className="relative mb-16">
       <div className="text-center pt-4">
-        <h1 className="text-[48px] font-medium text-[#1a202c] font-['DM_Sans'] tracking-[-1px] leading-[52px] text-center mx-auto antialiased">
+        <h1 className="text-[48px] font-medium bg-clip-text text-transparent bg-gradient-to-r from-white via-[#79C1FF] to-[#D9D9D9] font-['DM_Sans'] tracking-[-1px] leading-[52px] text-center mx-auto antialiased">
           {title}
         </h1>
-        <p className="text-gray-600 text-lg font-['DM_Sans'] mt-4">
-          Conduct in-depth company diligence powered by TAG ai
+        <p className="text-[#D9D9D9] text-lg font-['DM_Sans'] mt-4 max-w-2xl mx-auto">
+          AI-native risk intelligence for the Ole Miss Finance Club—streaming live diligence and hidden risk scoring in real time.
         </p>
       </div>
       <div className="absolute top-0 right-0 flex items-center space-x-4">

--- a/ui/src/components/LocationInput.tsx
+++ b/ui/src/components/LocationInput.tsx
@@ -14,13 +14,13 @@ const LocationInput: React.FC<LocationInputProps> = ({ value, onChange, classNam
 
   return (
     <div className="relative group">
-      <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
-      <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#468BFF] transition-all duration-200 group-hover:stroke-[#8FBCFA] z-10" strokeWidth={1.5} />
+      <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
+      <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#79C1FF] transition-all duration-200 group-hover:stroke-white z-10" strokeWidth={1.5} />
       <input
         type="text"
         value={value}
         onChange={handleInputChange}
-        className={`${className} !font-['DM_Sans']`}
+        className={`${className} !font-['DM_Sans'] placeholder-[#D9D9D9]/50`}
         placeholder="City, Country"
       />
     </div>

--- a/ui/src/components/ResearchBriefings.tsx
+++ b/ui/src/components/ResearchBriefings.tsx
@@ -21,8 +21,8 @@ const ResearchBriefings: React.FC<ResearchBriefingsProps> = ({
   onToggleExpand,
   isResetting
 }) => {
-  const glassStyle = "backdrop-filter backdrop-blur-lg bg-white/80 border border-gray-200 shadow-xl";
-  const cardGlassStyle = "backdrop-filter backdrop-blur-lg bg-white/80 shadow-sm";
+  const glassStyle = "backdrop-filter backdrop-blur-2xl bg-white/10 border border-white/15 shadow-[0_20px_60px_rgba(0,0,0,0.45)] text-white";
+  const cardGlassStyle = "backdrop-filter backdrop-blur-xl bg-white/10 shadow-sm text-white";
 
   return (
     <div 
@@ -34,10 +34,10 @@ const ResearchBriefings: React.FC<ResearchBriefingsProps> = ({
         className="flex items-center justify-between cursor-pointer"
         onClick={onToggleExpand}
       >
-        <h2 className="text-xl font-semibold text-gray-900">
+        <h2 className="text-xl font-semibold text-white">
           Research Briefings
         </h2>
-        <button className="text-gray-600 hover:text-gray-900 transition-colors">
+        <button className="text-[#D9D9D9] hover:text-white transition-colors">
           {isExpanded ? (
             <ChevronUp className="h-6 w-6" />
           ) : (
@@ -54,29 +54,29 @@ const ResearchBriefings: React.FC<ResearchBriefingsProps> = ({
             <div 
               key={category} 
               className={`${cardGlassStyle} rounded-lg p-4 transition-all duration-500 ease-in-out relative ${
-                briefingStatus[category as keyof BriefingStatus] 
-                  ? 'border border-[#468BFF] bg-gradient-to-br from-[#468BFF]/5 to-[#468BFF]/10 shadow-md' 
-                  : 'border border-gray-200 bg-white/80 hover:border-gray-300 hover:shadow-sm'
+                briefingStatus[category as keyof BriefingStatus]
+                  ? 'border border-[#0078D2] bg-gradient-to-br from-[#0078D2]/20 to-transparent shadow-md'
+                  : 'border border-white/15 bg-white/5 hover:border-white/30 hover:shadow-sm'
               } backdrop-blur-sm group`}
             >
               {/* Background decoration element (only visible when active) */}
               <div 
-                className={`absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(70,139,255,0.15),transparent_70%)] opacity-0 transition-opacity duration-700 ease-in-out rounded-lg ${
+                className={`absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(0,120,210,0.3),transparent_70%)] opacity-0 transition-opacity duration-700 ease-in-out rounded-lg ${
                   briefingStatus[category as keyof BriefingStatus] ? 'opacity-100' : ''
                 }`}
                 style={{ pointerEvents: 'none' }}
               />
-              
+
               <div className="relative z-10 flex items-center justify-between">
                 <h3 className={`text-sm font-medium capitalize transition-all duration-500 ${
                   briefingStatus[category as keyof BriefingStatus]
-                    ? 'text-[#468BFF]'
-                    : 'text-gray-700 group-hover:text-gray-900'
+                    ? 'text-[#79C1FF]'
+                    : 'text-[#D9D9D9] group-hover:text-white'
                 }`}>{category}</h3>
                 {briefingStatus[category as keyof BriefingStatus] ? (
-                  <CheckCircle2 className="h-4 w-4 text-[#468BFF] transition-all duration-300" />
+                  <CheckCircle2 className="h-4 w-4 text-[#79C1FF] transition-all duration-300" />
                 ) : (
-                  <div className="h-4 w-4 rounded-full border border-gray-200 group-hover:border-gray-300 transition-all duration-300"></div>
+                  <div className="h-4 w-4 rounded-full border border-white/20 group-hover:border-white/40 transition-all duration-300"></div>
                 )}
               </div>
             </div>
@@ -85,7 +85,7 @@ const ResearchBriefings: React.FC<ResearchBriefingsProps> = ({
       </div>
 
       {!isExpanded && (
-        <div className="mt-2 text-sm text-gray-600">
+        <div className="mt-2 text-sm text-[#D9D9D9]">
           {Object.values(briefingStatus).filter(Boolean).length} of {Object.keys(briefingStatus).length} briefings completed
         </div>
       )}

--- a/ui/src/components/ResearchForm.tsx
+++ b/ui/src/components/ResearchForm.tsx
@@ -129,20 +129,20 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
       />
 
       {/* Main Form */}
-      <div className={`${glassStyle.card} backdrop-blur-2xl bg-white/90 border-gray-200/50 shadow-xl`}>
+      <div className={`${glassStyle.card} bg-white/10 border-white/15 shadow-[0_30px_80px_rgba(0,0,0,0.45)]`}>
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {/* Company Name */}
             <div className="relative group">
               <label
                 htmlFor="companyName"
-                className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
+                className="block text-base font-medium text-[#D9D9D9] mb-2.5 transition-all duration-200 group-hover:text-white font-['DM_Sans']"
               >
-                Company Name <span className="text-gray-900/70">*</span>
+                Company Name <span className="text-white/70">*</span>
               </label>
               <div className="relative">
-                <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
-                <Building2 className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#468BFF] transition-all duration-200 group-hover:stroke-[#8FBCFA] z-10" strokeWidth={1.5} />
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
+                <Building2 className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#79C1FF] transition-all duration-200 group-hover:stroke-white z-10" strokeWidth={1.5} />
                 <input
                   required
                   id="companyName"
@@ -154,7 +154,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                       companyName: e.target.value,
                     }))
                   }
-                  className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
+                  className={`${glassStyle.input} transition-all duration-300 focus:border-[#0078D2]/70 focus:ring-1 focus:ring-[#0078D2]/40 group-hover:border-[#0078D2]/40 text-lg py-4 pl-12 font-['DM_Sans'] placeholder-[#D9D9D9]/50`}
                   placeholder="Enter company name"
                 />
               </div>
@@ -164,13 +164,13 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
             <div className="relative group">
               <label
                 htmlFor="companyUrl"
-                className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
+                className="block text-base font-medium text-[#D9D9D9] mb-2.5 transition-all duration-200 group-hover:text-white font-['DM_Sans']"
               >
                 Company URL
               </label>
               <div className="relative">
-                <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
-                <Globe className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#468BFF] transition-all duration-200 group-hover:stroke-[#8FBCFA] z-10" strokeWidth={1.5} />
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
+                <Globe className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#79C1FF] transition-all duration-200 group-hover:stroke-white z-10" strokeWidth={1.5} />
                 <input
                   id="companyUrl"
                   type="text"
@@ -181,7 +181,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                       companyUrl: e.target.value,
                     }))
                   }
-                  className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
+                  className={`${glassStyle.input} transition-all duration-300 focus:border-[#0078D2]/70 focus:ring-1 focus:ring-[#0078D2]/40 group-hover:border-[#0078D2]/40 text-lg py-4 pl-12 font-['DM_Sans'] placeholder-[#D9D9D9]/50`}
                   placeholder="example.com"
                 />
               </div>
@@ -191,7 +191,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
             <div className="relative group">
               <label
                 htmlFor="companyHq"
-                className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
+                className="block text-base font-medium text-[#D9D9D9] mb-2.5 transition-all duration-200 group-hover:text-white font-['DM_Sans']"
               >
                 Company HQ
               </label>
@@ -203,7 +203,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                     companyHq: value,
                   }))
                 }
-                className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
+                className={`${glassStyle.input} transition-all duration-300 focus:border-[#0078D2]/70 focus:ring-1 focus:ring-[#0078D2]/40 group-hover:border-[#0078D2]/40 text-lg py-4 pl-12 font-['DM_Sans'] placeholder-[#D9D9D9]/50`}
               />
             </div>
 
@@ -211,13 +211,13 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
             <div className="relative group">
               <label
                 htmlFor="companyIndustry"
-                className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
+                className="block text-base font-medium text-[#D9D9D9] mb-2.5 transition-all duration-200 group-hover:text-white font-['DM_Sans']"
               >
                 Company Industry
               </label>
               <div className="relative">
-                <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
-                <Factory className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#468BFF] transition-all duration-200 group-hover:stroke-[#8FBCFA] z-10" strokeWidth={1.5} />
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
+                <Factory className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 stroke-[#79C1FF] transition-all duration-200 group-hover:stroke-white z-10" strokeWidth={1.5} />
                 <input
                   id="companyIndustry"
                   type="text"
@@ -228,7 +228,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                       companyIndustry: e.target.value,
                     }))
                   }
-                  className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
+                  className={`${glassStyle.input} transition-all duration-300 focus:border-[#0078D2]/70 focus:ring-1 focus:ring-[#0078D2]/40 group-hover:border-[#0078D2]/40 text-lg py-4 pl-12 font-['DM_Sans'] placeholder-[#D9D9D9]/50`}
                   placeholder="e.g. Technology, Healthcare"
                 />
               </div>
@@ -238,19 +238,19 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
           <button
             type="submit"
             disabled={isResearching || !formData.companyName}
-            className="relative group w-fit mx-auto block overflow-hidden rounded-lg bg-white/80 backdrop-blur-sm border border-gray-200 transition-all duration-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed px-12 font-['DM_Sans']"
+            className="relative group w-fit mx-auto block overflow-hidden rounded-lg bg-[#0078D2] border border-[#79C1FF]/60 text-white transition-all duration-500 hover:bg-[#2F8FE6] disabled:opacity-50 disabled:cursor-not-allowed px-12 font-['DM_Sans'] shadow-[0_20px_60px_rgba(0,0,0,0.45)]"
           >
-            <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-1000"></div>
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-1000"></div>
             <div className="relative flex items-center justify-center py-3.5">
               {isResearching ? (
                 <>
                   <Loader2 className="animate-spin -ml-1 mr-2 h-5 w-5 loader-icon" style={{ stroke: loaderColor }} />
-                  <span className="text-base font-medium text-gray-900/90">Researching...</span>
+                  <span className="text-base font-medium text-white">Researching...</span>
                 </>
               ) : (
                 <>
-                  <Search className="-ml-1 mr-2 h-5 w-5 text-gray-900/90" />
-                  <span className="text-base font-medium text-gray-900/90">Start Research</span>
+                  <Search className="-ml-1 mr-2 h-5 w-5 text-white" />
+                  <span className="text-base font-medium text-white">Start Research</span>
                 </>
               )}
             </div>

--- a/ui/src/components/ResearchQueries.tsx
+++ b/ui/src/components/ResearchQueries.tsx
@@ -21,10 +21,10 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
         className="flex items-center justify-between cursor-pointer"
         onClick={onToggleExpand}
       >
-        <h2 className="text-xl font-semibold text-gray-900">
+        <h2 className="text-xl font-semibold text-white">
           Generated Research Queries
         </h2>
-        <button className="text-gray-600 hover:text-gray-900 transition-colors">
+        <button className="text-[#D9D9D9] hover:text-white transition-colors">
           {isExpanded ? (
             <ChevronUp className="h-6 w-6" />
           ) : (
@@ -32,14 +32,14 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
           )}
         </button>
       </div>
-      
+
       <div className={`overflow-hidden transition-all duration-500 ease-in-out ${
         isExpanded ? 'mt-4 max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
       }`}>
         <div className="grid grid-cols-2 gap-4">
           {['company', 'industry', 'financial', 'news'].map((category) => (
-            <div key={category} className={`${glassStyle} rounded-xl p-3`}>
-              <h3 className="text-base font-medium text-gray-900 mb-3 capitalize">
+            <div key={category} className={`${glassStyle} rounded-xl p-3 bg-white/5`}>
+              <h3 className="text-base font-medium text-white mb-3 capitalize">
                 {category.charAt(0).toUpperCase() + category.slice(1)} Queries
               </h3>
               <div className="space-y-2">
@@ -47,17 +47,17 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
                 {Object.entries(streamingQueries)
                   .filter(([key]) => key.startsWith(category))
                   .map(([key, query]) => (
-                    <div key={key} className="backdrop-filter backdrop-blur-lg bg-white/80 border border-[#468BFF]/30 rounded-lg p-2">
-                      <span className="text-gray-600">{query.text}</span>
-                      <span className="animate-pulse ml-1 text-[#8FBCFA]">|</span>
+                    <div key={key} className="backdrop-filter backdrop-blur-lg bg-[#0078D2]/20 border border-[#0078D2]/40 rounded-lg p-2 stream-fade">
+                      <span className="text-[#D9D9D9]">{query.text}</span>
+                      <span className="animate-pulse ml-1 text-[#0078D2]">|</span>
                     </div>
                   ))}
                 {/* Then show completed queries */}
                 {queries
                   .filter((q) => q.category.startsWith(category))
                   .map((query, idx) => (
-                    <div key={idx} className="backdrop-filter backdrop-blur-lg bg-white/80 border border-gray-200 rounded-lg p-2">
-                      <span className="text-gray-600">{query.text}</span>
+                    <div key={idx} className="backdrop-filter backdrop-blur-lg bg-white/5 border border-white/10 rounded-lg p-2 stream-fade">
+                      <span className="text-[#D9D9D9]">{query.text}</span>
                     </div>
                   ))}
               </div>
@@ -65,9 +65,9 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
           ))}
         </div>
       </div>
-      
+
       {!isExpanded && (
-        <div className="mt-2 text-sm text-gray-600">
+        <div className="mt-2 text-sm text-[#D9D9D9]">
           {queries.length} queries generated across {['company', 'industry', 'financial', 'news'].length} categories
         </div>
       )}

--- a/ui/src/components/ResearchReport.tsx
+++ b/ui/src/components/ResearchReport.tsx
@@ -44,7 +44,7 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
           <>
             <button
               onClick={onCopyToClipboard}
-              className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#468BFF] text-white hover:bg-[#8FBCFA] transition-all duration-200"
+              className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#0078D2] text-white hover:bg-[#2F8FE6] transition-all duration-200"
             >
               {isCopied ? (
                 <Check className="h-5 w-5" />
@@ -55,7 +55,7 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
             <button
               onClick={onGeneratePdf}
               disabled={isGeneratingPdf}
-              className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#FFB800] text-white hover:bg-[#FFA800] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-[#8A1C33] text-white hover:bg-[#A32B45] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isGeneratingPdf ? (
                 <>
@@ -79,7 +79,7 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
             remarkPlugins={[remarkGfm]}
             components={{
               div: ({node, ...props}) => (
-                <div className="space-y-4 text-gray-800" {...props} />
+                <div className="space-y-4 text-[#D9D9D9] stream-fade" {...props} />
               ),
               h1: ({node, children, ...props}) => {
                 const text = String(children);
@@ -87,8 +87,8 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
                 const isReferences = text.includes("References");
                 return (
                   <div>
-                    <h1 
-                      className={`font-bold text-gray-900 break-words whitespace-pre-wrap ${isFirstH1 ? 'text-5xl mb-10 mt-4 max-w-[calc(100%-8rem)]' : 'text-3xl mb-6'}`} 
+                    <h1
+                      className={`font-bold text-white break-words whitespace-pre-wrap ${isFirstH1 ? 'text-5xl mb-10 mt-4 max-w-[calc(100%-8rem)]' : 'text-3xl mb-6'}`}
                       {...props} 
                     >
                       {children}
@@ -100,10 +100,10 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
                 );
               },
               h2: ({node, ...props}) => (
-                <h2 className="text-3xl font-bold text-gray-900 first:mt-2 mt-8 mb-4" {...props} />
+                <h2 className="text-3xl font-bold text-white first:mt-2 mt-8 mb-4" {...props} />
               ),
               h3: ({node, ...props}) => (
-                <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3" {...props} />
+                <h3 className="text-xl font-semibold text-white mt-6 mb-3" {...props} />
               ),
               p: ({node, children, ...props}) => {
                 const text = String(children);
@@ -115,7 +115,7 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
                 
                 if (isSubsectionHeader) {
                   return (
-                    <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">
+                    <h3 className="text-xl font-semibold text-white mt-6 mb-3">
                       {text.endsWith(':') ? text.slice(0, -1) : text}
                     </h3>
                   );
@@ -125,8 +125,8 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
                 if (isBulletLabel) {
                   const [label, content] = text.split(':');
                   return (
-                    <div className="text-gray-800 my-2">
-                      <span className="font-semibold text-gray-900">
+                    <div className="text-[#D9D9D9] my-2">
+                      <span className="font-semibold text-white">
                         {label.replace('•', '').trim()}:
                       </span>
                       {content}
@@ -138,13 +138,13 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
                 if (urlRegex.test(text)) {
                   const parts = text.split(urlRegex);
                   return (
-                    <p className="text-gray-800 my-2" {...props}>
+                    <p className="text-[#D9D9D9] my-2" {...props}>
                       {parts.map((part, i) => 
                         urlRegex.test(part) ? (
-                          <a 
+                          <a
                             key={i}
                             href={part}
-                            className="text-[#468BFF] hover:text-[#8FBCFA] underline decoration-[#468BFF] hover:decoration-[#8FBCFA] cursor-pointer transition-colors"
+                            className="text-[#79C1FF] hover:text-[#A9D8FF] underline decoration-[#79C1FF] hover:decoration-[#A9D8FF] cursor-pointer transition-colors"
                             target="_blank"
                             rel="noopener noreferrer"
                           >
@@ -156,18 +156,18 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
                   );
                 }
                 
-                return <p className="text-gray-800 my-2" {...props}>{children}</p>;
+                return <p className="text-[#D9D9D9] my-2 stream-fade" {...props}>{children}</p>;
               },
               ul: ({node, ...props}) => (
-                <ul className="text-gray-800 space-y-1 list-disc pl-6" {...props} />
+                <ul className="text-[#D9D9D9] space-y-1 list-disc pl-6 stream-fade" {...props} />
               ),
               li: ({node, ...props}) => (
-                <li className="text-gray-800" {...props} />
+                <li className="text-[#D9D9D9]" {...props} />
               ),
               a: ({node, href, ...props}) => (
-                <a 
+                <a
                   href={href}
-                  className="text-[#468BFF] hover:text-[#8FBCFA] underline decoration-[#468BFF] hover:decoration-[#8FBCFA] cursor-pointer transition-colors" 
+                  className="text-[#79C1FF] hover:text-[#A9D8FF] underline decoration-[#79C1FF] hover:decoration-[#A9D8FF] cursor-pointer transition-colors"
                   target="_blank"
                   rel="noopener noreferrer"
                   {...props} 

--- a/ui/src/components/ResearchStatus.tsx
+++ b/ui/src/components/ResearchStatus.tsx
@@ -18,37 +18,37 @@ const ResearchStatus: React.FC<ResearchStatusProps> = ({
   if (!status) return null;
 
   return (
-    <div 
-      ref={statusRef} 
-      className={`${glassCardStyle} ${fadeInAnimation} ${isResetting ? 'opacity-0 transform -translate-y-4' : 'opacity-100 transform translate-y-0'} bg-white/80 backdrop-blur-sm border-gray-200 font-['DM_Sans']`}
+    <div
+      ref={statusRef}
+      className={`${glassCardStyle} ${fadeInAnimation} ${isResetting ? 'opacity-0 transform -translate-y-4' : 'opacity-100 transform translate-y-0'} bg-white/10 border-white/15 font-['DM_Sans']`}
     >
       <div className="flex items-center space-x-4">
         <div className="flex-shrink-0">
           {error ? (
-            <div className={`${glassStyle.base} p-2 rounded-full bg-[#FE363B]/10 border-[#FE363B]/20`}>
-              <XCircle className="h-5 w-5 text-[#FE363B]" />
+            <div className={`${glassStyle.base} p-2 rounded-full bg-[#8A1C33]/20 border-[#8A1C33]/40`}>
+              <XCircle className="h-5 w-5 text-[#FFD3DC]" />
             </div>
           ) : status?.step === "Complete" || isComplete ? (
-            <div className={`${glassStyle.base} p-2 rounded-full bg-[#22C55E]/10 border-[#22C55E]/20`}>
-              <CheckCircle2 className="h-5 w-5 text-[#22C55E]" />
+            <div className={`${glassStyle.base} p-2 rounded-full bg-white/10 border-white/30`}>
+              <CheckCircle2 className="h-5 w-5 text-white" />
             </div>
           ) : currentPhase === 'search' || currentPhase === 'enrichment' || (status?.step === "Processing" && status.message.includes("scraping")) ? (
-            <div className={`${glassStyle.base} p-2 rounded-full bg-[#468BFF]/10 border-[#468BFF]/20`}>
+            <div className={`${glassStyle.base} p-2 rounded-full bg-[#0078D2]/20 border-[#0078D2]/40`}>
               <Loader2 className="h-5 w-5 animate-spin loader-icon" style={{ stroke: loaderColor }} />
             </div>
           ) : currentPhase === 'briefing' ? (
-            <div className={`${glassStyle.base} p-2 rounded-full bg-[#468BFF]/10 border-[#468BFF]/20`}>
+            <div className={`${glassStyle.base} p-2 rounded-full bg-[#0078D2]/20 border-[#0078D2]/40`}>
               <Loader2 className="h-5 w-5 animate-spin loader-icon" style={{ stroke: loaderColor }} />
             </div>
           ) : (
-            <div className={`${glassStyle.base} p-2 rounded-full bg-[#468BFF]/10 border-[#468BFF]/20`}>
+            <div className={`${glassStyle.base} p-2 rounded-full bg-[#0078D2]/20 border-[#0078D2]/40`}>
               <Loader2 className="h-5 w-5 animate-spin loader-icon" style={{ stroke: loaderColor }} />
             </div>
           )}
         </div>
         <div className="flex-1">
-          <p className="font-medium text-gray-900/90">{status.step}</p>
-          <p className="text-sm text-gray-600 whitespace-pre-wrap">
+          <p className="font-medium text-white stream-fade">{status.step}</p>
+          <p className="text-sm text-[#D9D9D9] whitespace-pre-wrap stream-fade">
             {error || status.message}
           </p>
         </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -5,49 +5,28 @@
 @tailwind utilities;
 
 :root {
-  /* Light mode colors */
-  --color-bg-primary: #f8fafc;
-  --color-bg-secondary: #f1f5f9;
-  --color-text-primary: #0f172a;
-  --color-text-secondary: #334155;
-  --color-accent: #3b82f6;
-  --color-border: rgba(30, 41, 59, 0.1);
-  --color-glass-bg: rgba(255, 255, 255, 0.7);
-  --color-glass-border: rgba(148, 163, 184, 0.2);
-  --color-dot: rgba(0, 0, 0, 0.05);
-}
-
-.dark {
-  /* Dark mode colors */
-  --color-bg-primary: #121212;
-  --color-bg-secondary: #1e1e1e;
-  --color-text-primary: #f1f5f9;
-  --color-text-secondary: #94a3b8;
-  --color-accent: #468bff;
-  --color-border: rgba(255, 255, 255, 0.1);
-  --color-glass-bg: rgba(30, 30, 30, 0.4);
-  --color-glass-border: rgba(255, 255, 255, 0.1);
-  --color-dot: rgba(255, 255, 255, 0.05);
+  --color-bg-primary: #0b1831;
+  --color-bg-secondary: rgba(11, 24, 49, 0.85);
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #d9d9d9;
+  --color-accent: #0078d2;
+  --color-border: rgba(255, 255, 255, 0.18);
+  --color-glass-bg: rgba(11, 24, 49, 0.55);
+  --color-glass-border: rgba(255, 255, 255, 0.14);
+  --color-ember: #8a1c33;
 }
 
 @layer base {
   body {
-    @apply bg-gray-900;
+    @apply bg-slate-950;
     font-family: "DM Sans", sans-serif;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
-    background-color: var(--color-bg-primary);
+    background: radial-gradient(circle at 20% 20%, rgba(0, 120, 210, 0.25), transparent 55%),
+      radial-gradient(circle at 80% 10%, rgba(138, 28, 51, 0.35), transparent 60%),
+      linear-gradient(135deg, #0b1831 0%, #0b1831 45%, #8a1c33 120%);
     color: var(--color-text-primary);
-    background-image: radial-gradient(
-      circle at 1px 1px,
-      var(--color-dot) 1px,
-      transparent 0
-    );
-    background-size: 24px 24px;
-    background-position: center center;
-    transition:
-      background-color 0.3s ease,
-      color 0.3s ease;
+    transition: background 0.6s ease, color 0.3s ease;
   }
 
   h1 {
@@ -91,10 +70,7 @@
     border-color: var(--color-border);
   }
 
-  button {
-    font-family: "DM Sans", sans-serif;
-  }
-
+  button,
   select {
     font-family: "DM Sans", sans-serif;
   }
@@ -127,4 +103,26 @@
     background-color: var(--color-accent);
     color: white;
   }
+}
+
+@keyframes streamFadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(12px);
+    filter: blur(10px);
+  }
+  60% {
+    opacity: 0.65;
+    transform: translateY(0px);
+    filter: blur(4px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+.stream-fade {
+  animation: streamFadeIn 0.85s ease-out forwards;
 }


### PR DESCRIPTION
## Summary
- apply a deep-navy to crimson gradient theme with updated glassmorphism tokens and accent colors across the UI shell
- restyle core panels, forms, and streaming query/status modules for high-contrast typography and PitchGuard branding
- add a reusable stream-fade animation so live updates glide into view during research playback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e82a785094832ea965f97af1d0a741